### PR TITLE
Fix KVM error

### DIFF
--- a/day_20/hello.asm
+++ b/day_20/hello.asm
@@ -6,7 +6,7 @@ putloop:
 	MOV  AL,[CS:ECX]
 	CMP  AL,0
 	JE   fin
-	INT  0x40
+	INT  0x80
 	ADD  ECX,1
 	JMP  putloop
 

--- a/day_20/hello2.asm
+++ b/day_20/hello2.asm
@@ -1,7 +1,7 @@
 bits 32
 	MOV  EDX,2
 	MOV  EBX,msg
-	INT  0x40
+	INT  0x80
 	RETF
 msg:
 	DB  "hello",0


### PR DESCRIPTION
Linuxの場合，アプリケーションからOSを呼び出すのは のは `int 0x40` ではなく `int 0x80` らしい．

相変わらず期待する出力がでない理由はよくわからないが，とりあえず KVM がエラーを吐いて死ぬことはなくなった．